### PR TITLE
Fix #1918: Advanced Alchemical Furnace doesn't output essentia into alembics

### DIFF
--- a/src/main/java/tb/common/tile/TileAdvAlchemicalFurnace.java
+++ b/src/main/java/tb/common/tile/TileAdvAlchemicalFurnace.java
@@ -36,8 +36,18 @@ public class TileAdvAlchemicalFurnace extends TileAlchemyFurnace{
 				Class<TileAlchemyFurnace> furnace = TileAlchemyFurnace.class;
 				Field count = furnace.getDeclaredField("count");
 				count.setAccessible(true);
-				
-				count.setInt(this, count.getInt(this)+TBConfig.speedMultiplierForFurnace-1);
+				int furnaceUpdateStep = 20; //hardcoded in thaum to be 20 (when boosted) or 40, but let's assume 20 for simplicity
+				int currentCount = count.getInt(this);
+				//max meaningful bonus happens when (currentStep + 1 + bonus) % furnaceUpdateStep == 0, propagating us directly to next update count
+				//simple checks:
+				// if count=0, then we can add 19, thaum adds 1 and updates
+				// if count=19, then we add 0, the thaum will arrive to update at max speed without our help
+				// making sure to take remainders only from positives since java believes in negative remainders for negative dividends
+				int maxMeaningfulBonus = (furnaceUpdateStep  - (currentCount + 1) % furnaceUpdateStep)%furnaceUpdateStep;
+				int bonusCount = TBConfig.speedMultiplierForFurnace-1;
+				int nextCount = currentCount + Math.min(bonusCount, maxMeaningfulBonus);
+
+				count.setInt(this, nextCount);
 				
 				count.setAccessible(false);
 			}


### PR DESCRIPTION
Original bug caused by speedup method by extra increasing of tick count, skipping tick counts on which thaumcraft original method updates the alembics.
Fix makes sure that extra increase never skips update ticks.