### PR TITLE
Fix an issue with Node Linking Device

### DIFF
--- a/src/main/java/tb/common/tile/TileNodeLinker.java
+++ b/src/main/java/tb/common/tile/TileNodeLinker.java
@@ -334,30 +334,29 @@ public class TileNodeLinker extends TileEntity implements IWandable
 		paramEntityPlayer.swingItem();
 		if(!paramItemStack.hasTagCompound())
 			paramItemStack.setTagCompound(new NBTTagCompound());
-		
-		if(paramItemStack.getTagCompound().hasKey("linkCoordX"))
-		{
+
+		if(paramItemStack.getTagCompound().hasKey("linkCoordX")) {
 			float x = paramItemStack.getTagCompound().getFloat("linkCoordX");
 			float y = paramItemStack.getTagCompound().getFloat("linkCoordY");
 			float z = paramItemStack.getTagCompound().getFloat("linkCoordZ");
-			if(this.worldObj.getTileEntity(MathHelper.floor_double(x), MathHelper.floor_double(y), MathHelper.floor_double(z)) instanceof TileNodeLinker)
-			{
+			if (this.worldObj.getTileEntity(MathHelper.floor_double(x), MathHelper.floor_double(y), MathHelper.floor_double(z)) instanceof TileNodeLinker) {
 				TileNodeLinker tile = (TileNodeLinker) this.worldObj.getTileEntity(MathHelper.floor_double(x), MathHelper.floor_double(y), MathHelper.floor_double(z));
-				tile.linkCoord = new Coord3D(xCoord,yCoord,zCoord);
+				tile.linkCoord = new Coord3D(xCoord, yCoord, zCoord);
 				paramItemStack.getTagCompound().removeTag("linkCoordX");
 				paramItemStack.getTagCompound().removeTag("linkCoordY");
 				paramItemStack.getTagCompound().removeTag("linkCoordZ");
-				if(paramWorld.isRemote)
+				if (paramWorld.isRemote)
 					paramEntityPlayer.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("tb.txt.linkEstabilished")));
+
+				return paramItemStack;
 			}
-		}else
-		{
-			paramItemStack.getTagCompound().setFloat("linkCoordX", xCoord);
-			paramItemStack.getTagCompound().setFloat("linkCoordY", yCoord);
-			paramItemStack.getTagCompound().setFloat("linkCoordZ", zCoord);
-			if(paramWorld.isRemote)
-				paramEntityPlayer.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("tb.txt.linkStarted")));
 		}
+
+		paramItemStack.getTagCompound().setFloat("linkCoordX", xCoord);
+		paramItemStack.getTagCompound().setFloat("linkCoordY", yCoord);
+		paramItemStack.getTagCompound().setFloat("linkCoordZ", zCoord);
+		if(paramWorld.isRemote)
+			paramEntityPlayer.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("tb.txt.linkStarted")));
 		
 		return paramItemStack;
 	}


### PR DESCRIPTION
Case:
1) Place 2 Node Linking Device in the world
2) Click RMB on first device with thaumcraft wand in your hand to start linking process
3) Destroy first device
4) Now you cant finish linking process or restart it until you place first device back in the world on the same location.

Fixed this behavior - now if first device can't be found, the linking process have to restart