### PR TITLE
Adjust recipes for stabilizer blocks

### DIFF
--- a/src/main/java/tb/init/TBRecipes.java
+++ b/src/main/java/tb/init/TBRecipes.java
@@ -67,13 +67,15 @@ public class TBRecipes {
                 new Object[] { new ItemStack(TBBlocks.genLogs, 1, 2) });
 
         ShapedOreRecipe eAr = new ShapedOreRecipe(
-                new ItemStack(TBBlocks.eldritchArk, 5, 0),
-                new Object[] { "@#@", "###", "@#@", '@', "nuggetGold", '#', "obsidian" });
+                new ItemStack(TBBlocks.eldritchArk, 4, 0),
+                new Object[] { "@#@", "#$#", "@#@", '@', "nuggetGold", '#', "obsidian", '$',
+                        new ItemStack(ConfigBlocks.blockCrystal, 1, 4) });
 
         ShapedOreRecipe iGw = new ShapedOreRecipe(
-                new ItemStack(TBBlocks.ironGreatwood, 5, 0),
-                new Object[] { "@#@", "###", "@#@", '@', "nuggetIron", '#',
-                        new ItemStack(ConfigBlocks.blockWoodenDevice, 1, 6) });
+                new ItemStack(TBBlocks.ironGreatwood, 4, 0),
+                new Object[] { "@#@", "#$#", "@#@", '@', "nuggetIron", '#',
+                        new ItemStack(ConfigBlocks.blockWoodenDevice, 1, 6), '$',
+                        new ItemStack(ConfigBlocks.blockCrystal, 1, 4) });
 
         GameRegistry.addSmelting(new ItemStack(TBBlocks.genLogs, 1, 0), new ItemStack(Items.coal, 1, 1), 0.15F);
         GameRegistry.addSmelting(new ItemStack(TBBlocks.genLogs, 1, 1), new ItemStack(Items.coal, 1, 1), 0.15F);

--- a/src/main/java/tb/init/TBThaumonomicon.java
+++ b/src/main/java/tb/init/TBThaumonomicon.java
@@ -557,9 +557,10 @@ public class TBThaumonomicon {
 
         for (int i = 0; i < oldRec.length; ++i) oldRec[i] = new ShapedArcaneRecipe(
                 "TB.DecoBlocks",
-                new ItemStack(recResult[i], 6, 0),
-                new AspectList().add(Aspect.ENTROPY, 1),
-                new Object[] { "# #", "# #", "# #", '#', recBlocks[i] });
+                new ItemStack(recResult[i], 8, 0),
+                new AspectList().add(Aspect.ENTROPY, 5),
+                new Object[] { "###", "#@#", "###", '#', recBlocks[i], '@',
+                        new ItemStack(ConfigBlocks.blockCrystal, 1, 5) });
 
         ShapedArcaneRecipe advFurnaceRecipe = new ShapedArcaneRecipe(
                 "TB.AdvAlc",


### PR DESCRIPTION
These block were given stabilizer functionality last year here https://github.com/GTNewHorizons/ThaumicBases/pull/17, but without a look at the recipes.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12894.

This PR makes them slightly more expensive but the recipes are chosen so that they are still very much doable. This just brings it closer to other options. There was a thorough discussion on github and discord to ensure this is not an 'overnerf'. In fact I will still use the new recipes in my own run. :)

The most commonly used one in here is ancient cobblestone:

Old recipe:
![image](https://user-images.githubusercontent.com/40274384/225091362-043ea8c9-4629-4812-bdac-5504068d40d6.png)


New recipe: 
![image](https://user-images.githubusercontent.com/40274384/225090280-f40d5c12-b2e6-4e6b-a694-fa4dc8218261.png)

Besides ancient cobblestone this also affects ancient gravel, ancient mossy cobble, ancient bricks, ancient iron, ancient lapis, ancient gold, ancient diamonds, iron framed greatwood, and gold etched obsidian in the same way.