### PR TITLE
Fix stabilizer block check for Node Linker.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-	compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.148:dev') {transitive=false}
+	compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.155:dev') {transitive=false}
 
 	compile('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
 	compile('com.github.GTNewHorizons:CodeChickenLib:1.2.1:dev')

--- a/src/main/java/tb/common/tile/TileNodeLinker.java
+++ b/src/main/java/tb/common/tile/TileNodeLinker.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -152,23 +153,29 @@ public class TileNodeLinker extends TileEntity implements IWandable {
         } else instability = 0;
     }
 
+    private static final Block STABILIZER_BLOCK = OreDictionary.doesOreNameExist("blockIchorium")
+        && !OreDictionary.getOres("blockIchorium")
+            .isEmpty() ? Block.getBlockFromItem(
+                OreDictionary.getOres("blockIchorium")
+                    .get(0)
+                    .getItem())
+                : null;
+
+    private boolean hasStabilizerBlock() {
+        return STABILIZER_BLOCK != null
+            && this.worldObj.getBlock(this.xCoord, this.yCoord + 1, this.zCoord) == STABILIZER_BLOCK;
+    }
+
     public boolean instabilityCheck() {
         if (this.worldObj.rand.nextInt(50) <= this.instability) {
             int rnd = this.worldObj.rand.nextInt(this.instability);
             if (rnd == 49) {
                 // if a block of Ichorium is above dont explode or harm node
-                if (!OreDictionary.doesOreNameExist("blockIchorium")
-                    || (OreDictionary.getOres("blockIchorium") != null && !(OreDictionary.getOres("blockIchorium")
-                        .contains(new ItemStack(this.worldObj.getBlock(this.xCoord, this.yCoord + 1, this.zCoord))))))
-                    instability -= explodeTransmitter();
+                if (!hasStabilizerBlock()) instability -= explodeTransmitter();
             } else {
                 if (rnd >= 45) {
                     // if a block of Ichorium is above dont explode or harm node
-                    if (!OreDictionary.doesOreNameExist("blockIchorium")
-                        || (OreDictionary.getOres("blockIchorium") != null && !(OreDictionary.getOres("blockIchorium")
-                            .contains(
-                                new ItemStack(this.worldObj.getBlock(this.xCoord, this.yCoord + 1, this.zCoord))))))
-                        instability -= harmTransmitter();
+                    if (!hasStabilizerBlock()) instability -= harmTransmitter();
                 } else {
                     if (rnd >= 31) {
                         instability -= wisp();

--- a/src/main/java/tb/common/tile/TileNodeLinker.java
+++ b/src/main/java/tb/common/tile/TileNodeLinker.java
@@ -153,13 +153,13 @@ public class TileNodeLinker extends TileEntity implements IWandable {
         } else instability = 0;
     }
 
-    private static final Block STABILIZER_BLOCK = OreDictionary.doesOreNameExist("blockIchorium")
-        && !OreDictionary.getOres("blockIchorium")
-            .isEmpty() ? Block.getBlockFromItem(
-                OreDictionary.getOres("blockIchorium")
-                    .get(0)
-                    .getItem())
-                : null;
+    // Spotless messes this initialization up very badly. It is much clearer to read this way.
+    // spotless:off
+    private static final Block STABILIZER_BLOCK =
+        OreDictionary.doesOreNameExist("blockIchorium") && !OreDictionary.getOres("blockIchorium").isEmpty()
+            ? Block.getBlockFromItem(OreDictionary.getOres("blockIchorium").get(0).getItem())
+            : null;
+    // spotless:on
 
     private boolean hasStabilizerBlock() {
         return STABILIZER_BLOCK != null
@@ -171,11 +171,15 @@ public class TileNodeLinker extends TileEntity implements IWandable {
             int rnd = this.worldObj.rand.nextInt(this.instability);
             if (rnd == 49) {
                 // if a block of Ichorium is above dont explode or harm node
-                if (!hasStabilizerBlock()) instability -= explodeTransmitter();
+                if (!hasStabilizerBlock()) {
+                    instability -= explodeTransmitter();
+                }
             } else {
                 if (rnd >= 45) {
                     // if a block of Ichorium is above dont explode or harm node
-                    if (!hasStabilizerBlock()) instability -= harmTransmitter();
+                    if (!hasStabilizerBlock()) {
+                        instability -= harmTransmitter();
+                    }
                 } else {
                     if (rnd >= 31) {
                         instability -= wisp();


### PR DESCRIPTION
The Node Linking Device is supposed to be stabilized by a block of Ichorium placed above, preventing it from exploding when its instability gets too high. However, the check was implemented wrong (comparing `ItemStack`s does not work, as the class does not define an `equals` method).

This PR fixes it by comparing the `Block` instead. Additionally, the correct `Block` is cached at initialization, so that an ore dictionary query is not needed every tick.

Currently there is only one block of ichorium (matching `blockIchorium` in the ore dictionary) in the pack. If there is ever any reason to add more (for example, Chisel variants), this check needs to be adjusted so that it accepts any of them. With this PR, the first entry from the ore dictionary is always selected as the only valid stabilizer block.

Thanks to **@crzymn777** from discord for reporting this.