### PR TITLE
Add support for the Raw Ore Item to Ore Destruction

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,12 +1,12 @@
 // Add your dependencies here
 
 dependencies {
-	compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.48.14:dev') {transitive=false}
+	compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.48.33:dev') {transitive=false}
 
 	compile('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
 	compile('com.github.GTNewHorizons:CodeChickenLib:1.2.1:dev')
 	compile('com.github.GTNewHorizons:DummyCore:2.0.3:dev')
-	runtimeOnly("com.github.GTNewHorizons:NotEnoughItems:2.6.1-GTNH:dev")
+	runtimeOnly("com.github.GTNewHorizons:NotEnoughItems:2.6.5-GTNH:dev")
 
 	runtimeOnly('com.github.GTNewHorizons:Baubles:1.0.4:dev')
 	runtimeOnly('com.github.GTNewHorizons:CodeChickenCore:1.2.1:dev') // Required to allow dummycore to run in dev

--- a/src/main/java/tb/init/TBThaumonomicon.java
+++ b/src/main/java/tb/init/TBThaumonomicon.java
@@ -485,7 +485,7 @@ public class TBThaumonomicon {
                 new ItemStack(ConfigItems.itemResource, 1, 14) });
 
         CrucibleRecipe[] shards = new CrucibleRecipe[6];
-        if (Loader.isModLoaded("gregtech")) {
+        if (Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi")) {
 
             // Extend the size to support the new item inputs
             shards = new CrucibleRecipe[12];

--- a/src/main/java/tb/init/TBThaumonomicon.java
+++ b/src/main/java/tb/init/TBThaumonomicon.java
@@ -487,10 +487,10 @@ public class TBThaumonomicon {
         CrucibleRecipe[] shards = new CrucibleRecipe[6];
         if (Loader.isModLoaded("gregtech")) {
 
-            //Extend the size to support the new item inputs
+            // Extend the size to support the new item inputs
             shards = new CrucibleRecipe[12];
 
-            //Ore Blocks
+            // Ore Blocks
             shards[0] = new CrucibleRecipe(
                 "TB.OreDestruction",
                 new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 0),
@@ -538,53 +538,53 @@ public class TBThaumonomicon {
                 new AspectList().add(Aspect.MAGIC, 1)
                     .add(Aspect.ENTROPY, 5));
 
-            //Raw Ore Item
+            // Raw Ore Item
             shards[6] = new CrucibleRecipe(
-                    "TB.OreDestruction",
-                    new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 0),
-                    new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5540),
-                    new AspectList().add(Aspect.ENTROPY, 2)
-                            .add(Aspect.MAGIC, 1)
-                            .add(Aspect.AIR, 3));
+                "TB.OreDestruction",
+                new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 0),
+                new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5540),
+                new AspectList().add(Aspect.ENTROPY, 2)
+                    .add(Aspect.MAGIC, 1)
+                    .add(Aspect.AIR, 3));
 
             shards[7] = new CrucibleRecipe(
-                    "TB.OreDestruction",
-                    new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 1),
-                    new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5541),
-                    new AspectList().add(Aspect.ENTROPY, 2)
-                            .add(Aspect.MAGIC, 1)
-                            .add(Aspect.FIRE, 3));
+                "TB.OreDestruction",
+                new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 1),
+                new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5541),
+                new AspectList().add(Aspect.ENTROPY, 2)
+                    .add(Aspect.MAGIC, 1)
+                    .add(Aspect.FIRE, 3));
 
             shards[8] = new CrucibleRecipe(
-                    "TB.OreDestruction",
-                    new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 2),
-                    new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5543),
-                    new AspectList().add(Aspect.ENTROPY, 2)
-                            .add(Aspect.MAGIC, 1)
-                            .add(Aspect.WATER, 3));
+                "TB.OreDestruction",
+                new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 2),
+                new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5543),
+                new AspectList().add(Aspect.ENTROPY, 2)
+                    .add(Aspect.MAGIC, 1)
+                    .add(Aspect.WATER, 3));
 
             shards[9] = new CrucibleRecipe(
-                    "TB.OreDestruction",
-                    new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 3),
-                    new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5542),
-                    new AspectList().add(Aspect.ENTROPY, 2)
-                            .add(Aspect.MAGIC, 1)
-                            .add(Aspect.EARTH, 3));
+                "TB.OreDestruction",
+                new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 3),
+                new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5542),
+                new AspectList().add(Aspect.ENTROPY, 2)
+                    .add(Aspect.MAGIC, 1)
+                    .add(Aspect.EARTH, 3));
 
             shards[10] = new CrucibleRecipe(
-                    "TB.OreDestruction",
-                    new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 4),
-                    new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5545),
-                    new AspectList().add(Aspect.ENTROPY, 2)
-                            .add(Aspect.MAGIC, 1)
-                            .add(Aspect.ORDER, 3));
+                "TB.OreDestruction",
+                new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 4),
+                new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5545),
+                new AspectList().add(Aspect.ENTROPY, 2)
+                    .add(Aspect.MAGIC, 1)
+                    .add(Aspect.ORDER, 3));
 
             shards[11] = new CrucibleRecipe(
-                    "TB.OreDestruction",
-                    new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 5),
-                    new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5544),
-                    new AspectList().add(Aspect.MAGIC, 1)
-                            .add(Aspect.ENTROPY, 5));
+                "TB.OreDestruction",
+                new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 5),
+                new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5544),
+                new AspectList().add(Aspect.MAGIC, 1)
+                    .add(Aspect.ENTROPY, 5));
         } else {
 
             for (int i = 0; i < 6; ++i) shards[i] = new CrucibleRecipe(

--- a/src/main/java/tb/init/TBThaumonomicon.java
+++ b/src/main/java/tb/init/TBThaumonomicon.java
@@ -487,6 +487,10 @@ public class TBThaumonomicon {
         CrucibleRecipe[] shards = new CrucibleRecipe[6];
         if (Loader.isModLoaded("gregtech")) {
 
+            //Extend the size to support the new item inputs
+            shards = new CrucibleRecipe[12];
+
+            //Ore Blocks
             shards[0] = new CrucibleRecipe(
                 "TB.OreDestruction",
                 new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 0),
@@ -533,6 +537,54 @@ public class TBThaumonomicon {
                 new ItemStack(GameRegistry.findBlock("gregtech", "gt.blockores"), 1, 544),
                 new AspectList().add(Aspect.MAGIC, 1)
                     .add(Aspect.ENTROPY, 5));
+
+            //Raw Ore Item
+            shards[6] = new CrucibleRecipe(
+                    "TB.OreDestruction",
+                    new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 0),
+                    new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5540),
+                    new AspectList().add(Aspect.ENTROPY, 2)
+                            .add(Aspect.MAGIC, 1)
+                            .add(Aspect.AIR, 3));
+
+            shards[7] = new CrucibleRecipe(
+                    "TB.OreDestruction",
+                    new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 1),
+                    new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5541),
+                    new AspectList().add(Aspect.ENTROPY, 2)
+                            .add(Aspect.MAGIC, 1)
+                            .add(Aspect.FIRE, 3));
+
+            shards[8] = new CrucibleRecipe(
+                    "TB.OreDestruction",
+                    new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 2),
+                    new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5543),
+                    new AspectList().add(Aspect.ENTROPY, 2)
+                            .add(Aspect.MAGIC, 1)
+                            .add(Aspect.WATER, 3));
+
+            shards[9] = new CrucibleRecipe(
+                    "TB.OreDestruction",
+                    new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 3),
+                    new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5542),
+                    new AspectList().add(Aspect.ENTROPY, 2)
+                            .add(Aspect.MAGIC, 1)
+                            .add(Aspect.EARTH, 3));
+
+            shards[10] = new CrucibleRecipe(
+                    "TB.OreDestruction",
+                    new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 4),
+                    new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5545),
+                    new AspectList().add(Aspect.ENTROPY, 2)
+                            .add(Aspect.MAGIC, 1)
+                            .add(Aspect.ORDER, 3));
+
+            shards[11] = new CrucibleRecipe(
+                    "TB.OreDestruction",
+                    new ItemStack(ConfigItems.itemShard, TBConfig.shardsFromOre, 5),
+                    new ItemStack(GameRegistry.findItem("gregtech", "gt.metaitem.03"), 1, 5544),
+                    new AspectList().add(Aspect.MAGIC, 1)
+                            .add(Aspect.ENTROPY, 5));
         } else {
 
             for (int i = 0; i < 6; ++i) shards[i] = new CrucibleRecipe(


### PR DESCRIPTION
![image](https://github.com/GTNewHorizons/ThaumicBases/assets/3237986/6f715518-6e9e-4c7a-9f5c-90c4a625efb2)

Tested with and without Gregtech and no issues found.
The Array is only increased in size when Gregtech is loaded.