### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/thaumicbases/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicbases/lang/en_US.lang
@@ -12,6 +12,7 @@ tb.rec.enchantments.vaporising=Weapons enchanted with Vaporising enchantment hav
 #blocks
 tile.quicksilverBlock.name=Quicksilver Block
 tile.quicksilverBrick.name=Quicksilver Brick
+tile.crystalBlock.name=Crystal Block
 tile.crystalBlockfire.name=Fire Crystal Block
 tile.crystalBlockwater.name=Water Crystal Block
 tile.crystalBlockearth.name=Earth Crystal Block
@@ -41,6 +42,7 @@ tile.glieonia.name=Glieonia Crop
 tile.briar.name=Briar
 tile.tobacco.name=Tobacco Crop
 tile.voidPlant.name=Void Crop
+tile.spike.name=Spikes
 tile.spikeiron.name=Iron Spikes
 tile.spikethaumic.name=Thaumic Spikes
 tile.spikevoid.name=Void Spikes
@@ -60,6 +62,7 @@ tile.TBoldLapis.name=Ancient Lapis Lazuli Block
 tile.TBoldBricks.name=Ancient Bricks
 tile.nodeManipulator.name=Node Manipulator
 
+tile.tb.slab..name=Slab
 tile.tb.slab.tile.TBoldLapis.name=Ancient Lapis Lazuli Slab
 tile.tb.slab.tile.TBoldIron.name=Ancient Iron Slab
 tile.tb.slab.tile.TBoldGold.name=Ancient Gold Slab
@@ -69,6 +72,7 @@ tile.tb.slab.tile.TBoldBricks.name=Ancient Brick Slab
 tile.tb.slab.tile.TBoldCobblestoneMossy.name=Ancient Mossy Cobblestone Slab
 tile.tb.slab.tile.eldritchArk.name=Gold Etched Obsidian Slab
 
+tile.tb.crystalslab..name=Crystal Slab
 tile.tb.crystalslab.air.name=Air Crystal Slab
 tile.tb.crystalslab.water.name=Water Crystal Slab
 tile.tb.crystalslab.fire.name=Fire Crystal Slab
@@ -80,9 +84,11 @@ tile.tb.crystalslab.tainted.name=Tainted Crystal Slab
 
 tile.thaumicRelocator.name=Thaumic Relocator
 tile.tb.voidblock.name=Void metal Block
+tile.thaumicAnvil.name=Thaumium Anvil
 tile.thaumicAnvil.intact.name=Thaumium Anvil
 tile.thaumicAnvil.slightlyDamaged.name=Slightly Damaged Thaumium Anvil
 tile.thaumicAnvil.veryDamaged.name=Very Damaged Thaumium Anvil
+tile.voidAnvil.name=Void metal Anvil
 tile.voidAnvil.intact.name=Void metal Anvil
 tile.voidAnvil.slightlyDamaged.name=Slightly Damaged Void metal Anvil
 tile.voidAnvil.veryDamaged.name=Very Damaged Void metal Anvil
@@ -99,6 +105,7 @@ tile.enderTreeLeaves.name=Ender Leaves
 tile.enderPlanks.name=Ender Wood Planks
 
 #items
+item.resource.name=Resource
 item.resourcenuggetthauminite.name=Thauminite Nugget
 item.resourcethauminite.thauminite_ingot.name=Thauminite Ingot
 item.resourcethaumium_wand_core.name=Thaumium Wand Core
@@ -128,6 +135,7 @@ item.plaxSeeds.name=Plax Seeds
 item.metalleatSeeds.name=Metalleat Seeds
 item.lucriteSeeds.name=Lucrite Seeds
 item.knoseSeed.name=Rosa Mysteria Sprout
+item.knoseFragment..name=Fragment
 item.knoseFragment.fire.name=Ignis Fragment
 item.knoseFragment.aqua.name=Aqua Fragment
 item.knoseFragment.terra.name=Terra Fragment
@@ -144,6 +152,7 @@ item.rosehipSyrup.name=Rosehip Syrup
 
 item.greatwoodPipe.name=Greatwood Smoking Pipe
 item.silverwoodPipe.name=Silverwood Smoking Pipe
+item.tobacco.name=Tobacco Pile
 item.tobacco.tobacco_pile.name=Tobacco Pile
 item.tobacco.tobacco_eldritch.name=Eldritch Tobacco Pile
 item.tobacco.tobacco_fighting.name=Angry Tobacco Pile
@@ -168,6 +177,7 @@ item.fluxFoci.name=Wand Focus: Flux Scrubber
 item.drainFoci.name=Wand Focus: Liquid Drain
 item.experienceFoci.name=Wand Focus: Experience
 
+item.nodeFoci..name=§eNode Manipulator Focus
 item.nodeFoci.speed.name=§eNode Manipulator Focus: Speed
 item.nodeFoci.brightness.name=§eNode Manipulator Focus: Brightness
 item.nodeFoci.destruction.name=§eNode Manipulator Focus: Destruction
@@ -568,6 +578,7 @@ tile.tb.brazier.name=Brazier of Warding
 
 #Items
 item.tb.revolver.name=Thaumaturge's Revolver
+item.tb.bracelet.name=Bracelet
 item.tb.bracelet.iron=Iron Bracelet
 item.tb.bracelet.gold=Gold Bracelet
 item.tb.bracelet.greatwood=Greatwood Bracelet


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.