### PR TITLE
Fix quicksilverBrick rendering over Draconic Evolution core effects

### DIFF
--- a/src/main/java/tb/init/TBBlocks.java
+++ b/src/main/java/tb/init/TBBlocks.java
@@ -63,7 +63,7 @@ public class TBBlocks {
     public static Block quicksilverBlock = new TBBlockDeco(Material.iron, false).setBlockName("quicksilverBlock")
         .setBlockTextureName("thaumicbases:quicksilverBlock")
         .setHardness(1F);
-    public static Block quicksilverBrick = new TBBlockDeco(Material.rock, true).setBlockName("quicksilverBrick")
+    public static Block quicksilverBrick = new TBBlockDeco(Material.rock, false).setBlockName("quicksilverBrick")
         .setBlockTextureName("thaumicbases:quicksilverBrick")
         .setHardness(1F);
     public static Block crystalBlock = new BlockCrystalBlock().setBlockName("crystalBlock")


### PR DESCRIPTION
quicksilverBrick was set to render pass 1 (translucent) due to isGlass=true, causing it to render after TESR effects like the Draconic Evolution reactor core, visually covering them. Fixed by setting glass=false since the texture is fully opaque and has no reason to be in the translucent pass.

|Before|After|
|-|-|
|<img width="2560" height="1369" alt="java_XVKpeh48kT" src="https://github.com/user-attachments/assets/a9d04989-5126-4d2b-84e3-07a4c09545d5" />|<img width="2560" height="1369" alt="java_iqKxYkaWvz" src="https://github.com/user-attachments/assets/699076ef-5437-48a7-8bb8-ad85be3fa0f6" />| 