### PR TITLE
Fix overchanter desyncs + restore original timings and essentia consumption + declare dependency on GTNHLib

### DIFF
--- a/src/main/java/tb/common/tile/TileOverchanter.java
+++ b/src/main/java/tb/common/tile/TileOverchanter.java
@@ -50,22 +50,22 @@ public class TileOverchanter extends TileEntity implements ISidedInventory, IWan
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void updateEntity() {
-        if (!worldObj.isRemote) {
-            if (syncTimer <= 0) {
-                syncTimer = 100;
-                NBTTagCompound tg = new NBTTagCompound();
-                tg.setInteger("0", enchantingTicks);
-                tg.setInteger("1", xpToAbsorb);
-                tg.setBoolean("2", isEnchantingStarted);
-                tg.setInteger("x", xCoord);
-                tg.setInteger("y", yCoord);
-                tg.setInteger("z", zCoord);
-                MiscUtils.syncTileEntity(tg, 0);
-            } else {
-                --syncTimer;
-            }
+        if (worldObj.isRemote) {
+            return;
+        }
+        if (syncTimer <= 0) {
+            syncTimer = 100;
+            NBTTagCompound tg = new NBTTagCompound();
+            tg.setInteger("0", enchantingTicks);
+            tg.setInteger("1", xpToAbsorb);
+            tg.setBoolean("2", isEnchantingStarted);
+            tg.setInteger("x", xCoord);
+            tg.setInteger("y", yCoord);
+            tg.setInteger("z", zCoord);
+            MiscUtils.syncTileEntity(tg, 0);
+        } else {
+            --syncTimer;
         }
 
         if (this.inventory == null) {
@@ -79,10 +79,13 @@ public class TileOverchanter extends TileEntity implements ISidedInventory, IWan
                 this.worldObj
                     .playSoundEffect(this.xCoord, this.yCoord, this.zCoord, "thaumcraft:infuserstart", 1F, 1.0F);
                 if (EssentiaHandler.drainEssentia(this, Aspect.MAGIC, ForgeDirection.UNKNOWN, 8, false)) {
+                    // +1 is needed to exactly mimic original timings and not use extra 1 essentia (should be 32 in
+                    // perfect conditions)
+                    int enchantingSeconds = enchantingTicks / 20 + 1;
                     // the values being checked against are the second milestones in the enchanting process
-                    if (enchantingTicks / 20 >= 16) {
+                    if (enchantingSeconds >= 16) {
                         if (xpToAbsorb != 0) absorbXP();
-                        if (enchantingTicks / 20 >= 32 && xpToAbsorb == 0) {
+                        if (enchantingSeconds >= 32 && xpToAbsorb == 0) {
                             int enchId = this.findEnchantment(inventory);
                             NBTTagList nbttaglist = this.inventory.getEnchantmentTagList();
                             for (int i = 0; i < nbttaglist.tagCount(); ++i) {
@@ -134,7 +137,6 @@ public class TileOverchanter extends TileEntity implements ISidedInventory, IWan
         return false;
     }
 
-    @SuppressWarnings("unchecked")
     public int findEnchantment(ItemStack enchanted) {
         NBTTagCompound stackTag = MiscUtils.getStackTag(enchanted);
         LinkedHashMap<Integer, Integer> ench = (LinkedHashMap<Integer, Integer>) EnchantmentHelper
@@ -292,7 +294,7 @@ public class TileOverchanter extends TileEntity implements ISidedInventory, IWan
     @Override
     public int onWandRightClick(World world, ItemStack wandstack, EntityPlayer player, int x, int y, int z, int side,
         int md) {
-        if (canStartEnchanting()) {
+        if (!world.isRemote && canStartEnchanting()) {
             isEnchantingStarted = true;
             player.swingItem();
             syncTimer = 0;

--- a/src/main/java/tb/core/TBCore.java
+++ b/src/main/java/tb/core/TBCore.java
@@ -44,7 +44,7 @@ public class TBCore {
     public static final String name = "Thaumic Bases";
     public static final String serverProxy = "tb.network.proxy.TBServer";
     public static final String clientProxy = "tb.network.proxy.TBClient";
-    public static final String dependencies = "required-after:Thaumcraft@[4.2.3.5,);required-after:Baubles@[1.0.1.10,);required-after:DummyCore@[1.6,);";
+    public static final String dependencies = "required-after:Thaumcraft@[4.2.3.5,);required-after:Baubles@[1.0.1.10,);required-after:DummyCore@[1.6,);required-after:gtnhlib@[0.9.47,);";
 
     public static final TBConfig cfg = new TBConfig();
 


### PR DESCRIPTION
Currently overchanter has several desync issues:
- Starting enchanting with wand right click is unreliable, usually takes 2 clicks, sometimes 1 or 3
- Essentia drain is sometime desynced on server and client
- Displayed enchants levels on overchanted item sometimes desynced

I believe all this happening because TileEntity update logic runs both on server and client and do it inconsistently.
There is no point in running it on client side, so I added checks on `!world.isRemote`.

#59 did great with automation of overchanter but introduced issues:
- Added dependency on gtnhlib without declaring it in `@Mod` annotation
- Slightly broke timings of enchanting process: it became slightly longer and consumes 33 essentia instead of 32

Hopefully I fixed that issues too.